### PR TITLE
Update clinicaltrials.R

### DIFF
--- a/pcgrr/R/clinicaltrials.R
+++ b/pcgrr/R/clinicaltrials.R
@@ -55,9 +55,10 @@ generate_report_data_trials <- function(pcgr_data, config, sample_name) {
       dplyr::rename(intervention = .data$intervention2) %>%
       magrittr::set_colnames(toupper(names(.))) %>%
       dplyr::arrange(.data$N_PRIMARY_CANCER_SITES,
-                     .data$OVERALL_STATUS, dplyr::desc(.data$START_DATE),
-                     dplyr::desc(nchar(.data$BIOMARKER_INDEX),
-                          .data$STUDY_DESIGN_PRIMARY_PURPOSE)) %>%
+                     .data$OVERALL_STATUS,
+                     dplyr::desc(.data$START_DATE),
+                     dplyr::desc(nchar(.data$BIOMARKER_INDEX)),
+                     dplyr::desc(.data$STUDY_DESIGN_PRIMARY_PURPOSE)) %>%
       dplyr::select(-c(.data$N_PRIMARY_CANCER_SITES, .data$STUDY_DESIGN_PRIMARY_PURPOSE))
 
     if (nrow(pcg_report_trials[["trials"]]) > 2000) {


### PR DESCRIPTION
Fix "desc() must be called with exactly one argument" in report generation.
I have no idea why this was suddenly a problem _now_, but this seems to fix it.